### PR TITLE
Fix VGG19 and refactor regularized problems

### DIFF
--- a/deepobs/pytorch/testproblems/cifar100_3c3d.py
+++ b/deepobs/pytorch/testproblems/cifar100_3c3d.py
@@ -1,15 +1,14 @@
 # -*- coding: utf-8 -*-
 """A vanilla CNN architecture for CIFAR-100."""
 
-import torch
 from torch import nn
 
 from ..datasets.cifar100 import cifar100
-from .testproblem import TestProblem
+from .testproblem import WeightRegularizedTestproblem
 from .testproblems_modules import net_cifar10_3c3d
 
 
-class cifar100_3c3d(TestProblem):
+class cifar100_3c3d(WeightRegularizedTestproblem):
     """DeepOBS test problem class for a three convolutional and three dense \
     layered neural network on Cifar-100.
 
@@ -49,20 +48,3 @@ class cifar100_3c3d(TestProblem):
         self.net = net_cifar10_3c3d(num_outputs=100)
         self.net.to(self._device)
         self.regularization_groups = self.get_regularization_groups()
-
-    def get_regularization_groups(self):
-        """Creates regularization groups for the parameters.
-
-        Returns:
-            dict: A dictionary where the key is the regularization factor and the value is a list of parameters.
-        """
-        no, l2 = 0.0, self._l2_reg
-        group_dict = {no: [], l2: []}
-
-        for parameters_name, parameters in self.net.named_parameters():
-            # penalize only the non bias layer parameters
-            if "bias" not in parameters_name:
-                group_dict[l2].append(parameters)
-            else:
-                group_dict[no].append(parameters)
-        return group_dict

--- a/deepobs/pytorch/testproblems/cifar100_allcnnc.py
+++ b/deepobs/pytorch/testproblems/cifar100_allcnnc.py
@@ -4,11 +4,11 @@
 from torch import nn
 
 from ..datasets.cifar100 import cifar100
-from .testproblem import TestProblem
+from .testproblem import WeightRegularizedTestproblem
 from .testproblems_modules import net_cifar100_allcnnc
 
 
-class cifar100_allcnnc(TestProblem):
+class cifar100_allcnnc(WeightRegularizedTestproblem):
     """DeepOBS test problem class for the All Convolutional Neural Network C
   on Cifar-100.
 
@@ -54,20 +54,3 @@ class cifar100_allcnnc(TestProblem):
         self.net = net_cifar100_allcnnc()
         self.net.to(self._device)
         self.regularization_groups = self.get_regularization_groups()
-
-    def get_regularization_groups(self):
-        """Creates regularization groups for the parameters.
-
-        Returns:
-            dict: A dictionary where the key is the regularization factor and the value is a list of parameters.
-        """
-        no, l2 = 0.0, self._l2_reg
-        group_dict = {no: [], l2: []}
-
-        for parameters_name, parameters in self.net.named_parameters():
-            # penalize only the non bias layer parameters
-            if "bias" not in parameters_name:
-                group_dict[l2].append(parameters)
-            else:
-                group_dict[no].append(parameters)
-        return group_dict

--- a/deepobs/pytorch/testproblems/cifar100_vgg16.py
+++ b/deepobs/pytorch/testproblems/cifar100_vgg16.py
@@ -3,11 +3,11 @@
 from torch import nn
 
 from ..datasets.cifar100 import cifar100
-from .testproblem import TestProblem
+from .testproblem import WeightRegularizedTestproblem
 from .testproblems_modules import net_vgg
 
 
-class cifar100_vgg16(TestProblem):
+class cifar100_vgg16(WeightRegularizedTestproblem):
     """DeepOBS test problem class for the VGG 16 network on Cifar-100.
 
   The CIFAR-100 images are resized to ``224`` by ``224`` to fit the input
@@ -50,20 +50,3 @@ class cifar100_vgg16(TestProblem):
         self.net = net_vgg(num_outputs=100, variant=16)
         self.net.to(self._device)
         self.regularization_groups = self.get_regularization_groups()
-
-    def get_regularization_groups(self):
-        """Creates regularization groups for the parameters.
-
-        Returns:
-            dict: A dictionary where the key is the regularization factor and the value is a list of parameters.
-        """
-        no, l2 = 0.0, self._l2_reg
-        group_dict = {no: [], l2: []}
-
-        for parameters_name, parameters in self.net.named_parameters():
-            # penalize only the non bias layer parameters
-            if "bias" not in parameters_name:
-                group_dict[l2].append(parameters)
-            else:
-                group_dict[no].append(parameters)
-        return group_dict

--- a/deepobs/pytorch/testproblems/cifar100_vgg19.py
+++ b/deepobs/pytorch/testproblems/cifar100_vgg19.py
@@ -3,11 +3,11 @@
 from torch import nn
 
 from ..datasets.cifar100 import cifar100
-from .testproblem import TestProblem
+from .testproblem import WeightRegularizedTestproblem
 from .testproblems_modules import net_vgg
 
 
-class cifar100_vgg19(TestProblem):
+class cifar100_vgg19(WeightRegularizedTestproblem):
     """DeepOBS test problem class for the VGG 19 network on Cifar-100.
 
   The CIFAR-100 images are resized to ``224`` by ``224`` to fit the input
@@ -50,20 +50,3 @@ class cifar100_vgg19(TestProblem):
         self.net = net_vgg(num_outputs=100, variant=19)
         self.net.to(self._device)
         self.regularization_groups = self.get_regularization_groups()
-
-    def get_regularization_groups(self):
-        """Creates regularization groups for the parameters.
-
-        Returns:
-            dict: A dictionary where the key is the regularization factor and the value is a list of parameters.
-        """
-        no, l2 = 0.0, self._l2_reg
-        group_dict = {no: [], l2: []}
-
-        for parameters_name, parameters in self.net.named_parameters():
-            # penalize only the non bias layer parameters
-            if "bias" not in parameters_name:
-                group_dict[l2].append(parameters)
-            else:
-                group_dict[no].append(parameters)
-        return group_dict

--- a/deepobs/pytorch/testproblems/cifar100_vgg19.py
+++ b/deepobs/pytorch/testproblems/cifar100_vgg19.py
@@ -46,7 +46,7 @@ class cifar100_vgg19(TestProblem):
     def set_up(self):
         """Set up the VGG 19 test problem on Cifar-100."""
         self.data = cifar100(self._batch_size)
-        self.net = net_vgg(num_outputs=100, variant=19)
+        self.loss_function = nn.CrossEntropyLoss
         self.net = net_vgg(num_outputs=100, variant=19)
         self.net.to(self._device)
         self.regularization_groups = self.get_regularization_groups()

--- a/deepobs/pytorch/testproblems/cifar100_wrn164.py
+++ b/deepobs/pytorch/testproblems/cifar100_wrn164.py
@@ -1,12 +1,11 @@
-import torch
 from torch import nn
 
 from ..datasets.cifar100 import cifar100
-from .testproblem import TestProblem
+from .testproblem import Testproblem
 from .testproblems_modules import net_wrn
 
 
-class cifar100_wrn164(TestProblem):
+class cifar100_wrn164(Testproblem):
     """DeepOBS test problem class for the Wide Residual Network 16-4 architecture\
     for Cifar-100.
 
@@ -47,6 +46,7 @@ class cifar100_wrn164(TestProblem):
         self.net.to(self._device)
         self.regularization_groups = self.get_regularization_groups()
 
+    # TODO: Refactor, use WeightRegularizedTestproblem
     def get_regularization_groups(self):
         """Creates regularization groups for the parameters.
 

--- a/deepobs/pytorch/testproblems/cifar100_wrn164.py
+++ b/deepobs/pytorch/testproblems/cifar100_wrn164.py
@@ -1,11 +1,11 @@
 from torch import nn
 
 from ..datasets.cifar100 import cifar100
-from .testproblem import Testproblem
+from .testproblem import TestProblem
 from .testproblems_modules import net_wrn
 
 
-class cifar100_wrn164(Testproblem):
+class cifar100_wrn164(TestProblem):
     """DeepOBS test problem class for the Wide Residual Network 16-4 architecture\
     for Cifar-100.
 

--- a/deepobs/pytorch/testproblems/cifar100_wrn404.py
+++ b/deepobs/pytorch/testproblems/cifar100_wrn404.py
@@ -1,4 +1,3 @@
-import torch
 from torch import nn
 
 from ..datasets.cifar100 import cifar100
@@ -43,12 +42,11 @@ class cifar100_wrn404(TestProblem):
         """Set up the Wide ResNet 16-4 test problem on Cifar-100."""
         self.data = cifar100(self._batch_size)
         self.loss_function = nn.CrossEntropyLoss
-        self.net = net_wrn(
-            num_outputs=100, num_residual_blocks=6, widening_factor=4
-        )
+        self.net = net_wrn(num_outputs=100, num_residual_blocks=6, widening_factor=4)
         self.net.to(self._device)
         self.regularization_groups = self.get_regularization_groups()
 
+    # TODO: Refactor, use WeightRegularizedTestproblem
     def get_regularization_groups(self):
         """Creates regularization groups for the parameters.
 
@@ -66,4 +64,3 @@ class cifar100_wrn404(TestProblem):
                 group_dict[l2].append(parameters)
             else:
                 group_dict[no].append(parameters)
-

--- a/deepobs/pytorch/testproblems/cifar10_3c3d.py
+++ b/deepobs/pytorch/testproblems/cifar10_3c3d.py
@@ -4,11 +4,11 @@
 from torch import nn
 
 from ..datasets.cifar10 import cifar10
-from .testproblem import TestProblem
+from .testproblem import WeightRegularizedTestproblem
 from .testproblems_modules import net_cifar10_3c3d
 
 
-class cifar10_3c3d(TestProblem):
+class cifar10_3c3d(WeightRegularizedTestproblem):
     """DeepOBS test problem class for a three convolutional and three dense \
     layered neural network on Cifar-10.
 
@@ -59,20 +59,3 @@ class cifar10_3c3d(TestProblem):
         self.net = net_cifar10_3c3d(num_outputs=10)
         self.net.to(self._device)
         self.regularization_groups = self.get_regularization_groups()
-
-    def get_regularization_groups(self):
-        """Creates regularization groups for the parameters.
-
-        Returns:
-            dict: A dictionary where the key is the regularization factor and the value is a list of parameters.
-        """
-        no, l2 = 0.0, self._l2_reg
-        group_dict = {no: [], l2: []}
-
-        for parameters_name, parameters in self.net.named_parameters():
-            # penalize only the non bias layer parameters
-            if "bias" not in parameters_name:
-                group_dict[l2].append(parameters)
-            else:
-                group_dict[no].append(parameters)
-        return group_dict

--- a/deepobs/pytorch/testproblems/cifar10_vgg16.py
+++ b/deepobs/pytorch/testproblems/cifar10_vgg16.py
@@ -3,11 +3,11 @@
 from torch import nn
 
 from ..datasets.cifar10 import cifar10
-from .testproblem import TestProblem
+from .testproblem import WeightRegularizedTestproblem
 from .testproblems_modules import net_vgg
 
 
-class cifar10_vgg16(TestProblem):
+class cifar10_vgg16(WeightRegularizedTestproblem):
     """DeepOBS test problem class for the VGG 16 network on Cifar-10.
 
   The CIFAR-10 images are resized to ``224`` by ``224`` to fit the input
@@ -51,20 +51,3 @@ class cifar10_vgg16(TestProblem):
         self.net = net_vgg(num_outputs=10, variant=16)
         self.net.to(self._device)
         self.regularization_groups = self.get_regularization_groups()
-
-    def get_regularization_groups(self):
-        """Creates regularization groups for the parameters.
-
-        Returns:
-            dict: A dictionary where the key is the regularization factor and the value is a list of parameters.
-        """
-        no, l2 = 0.0, self._l2_reg
-        group_dict = {no: [], l2: []}
-
-        for parameters_name, parameters in self.net.named_parameters():
-            # penalize only the non bias layer parameters
-            if "bias" not in parameters_name:
-                group_dict[l2].append(parameters)
-            else:
-                group_dict[no].append(parameters)
-        return group_dict

--- a/deepobs/pytorch/testproblems/cifar10_vgg19.py
+++ b/deepobs/pytorch/testproblems/cifar10_vgg19.py
@@ -6,6 +6,7 @@ from ..datasets.cifar10 import cifar10
 from .testproblem import TestProblem
 from .testproblems_modules import net_vgg
 
+
 class cifar10_vgg19(TestProblem):
     """DeepOBS test problem class for the VGG 19 network on Cifar-10.
 
@@ -45,9 +46,9 @@ class cifar10_vgg19(TestProblem):
     def set_up(self):
         """Set up the VGG 19 test problem on Cifar-10."""
         self.data = cifar10(self._batch_size)
+        self.loss_function = nn.CrossEntropyLoss
         self.net = net_vgg(num_outputs=10, variant=19)
-        self.net = net_vgg(num_outputs=10,variant=19)
-        self.net = net_vgg(num_outputs=10, variant=19)
+        self.net.to(self._device)
         self.regularization_groups = self.get_regularization_groups()
 
     def get_regularization_groups(self):

--- a/deepobs/pytorch/testproblems/cifar10_vgg19.py
+++ b/deepobs/pytorch/testproblems/cifar10_vgg19.py
@@ -3,11 +3,11 @@
 from torch import nn
 
 from ..datasets.cifar10 import cifar10
-from .testproblem import TestProblem
+from .testproblem import WeightRegularizedTestproblem
 from .testproblems_modules import net_vgg
 
 
-class cifar10_vgg19(TestProblem):
+class cifar10_vgg19(WeightRegularizedTestproblem):
     """DeepOBS test problem class for the VGG 19 network on Cifar-10.
 
   The CIFAR-10 images are resized to ``224`` by ``224`` to fit the input
@@ -50,20 +50,3 @@ class cifar10_vgg19(TestProblem):
         self.net = net_vgg(num_outputs=10, variant=19)
         self.net.to(self._device)
         self.regularization_groups = self.get_regularization_groups()
-
-    def get_regularization_groups(self):
-        """Creates regularization groups for the parameters.
-
-        Returns:
-            dict: A dictionary where the key is the regularization factor and the value is a list of parameters.
-        """
-        no, l2 = 0.0, self._l2_reg
-        group_dict = {no: [], l2: []}
-
-        for parameters_name, parameters in self.net.named_parameters():
-            # penalize only the non bias layer parameters
-            if "bias" not in parameters_name:
-                group_dict[l2].append(parameters)
-            else:
-                group_dict[no].append(parameters)
-        return group_dict

--- a/deepobs/pytorch/testproblems/svhn_3c3d.py
+++ b/deepobs/pytorch/testproblems/svhn_3c3d.py
@@ -1,12 +1,11 @@
-import torch
 from torch import nn
 
 from ..datasets.svhn import svhn
-from .testproblem import TestProblem
+from .testproblem import WeightRegularizedTestproblem
 from .testproblems_modules import net_cifar10_3c3d
 
 
-class svhn_3c3d(TestProblem):
+class svhn_3c3d(WeightRegularizedTestproblem):
     """DeepOBS test problem class for a three convolutional and three dense \
     layered neural network on SVHN.
 
@@ -51,20 +50,3 @@ class svhn_3c3d(TestProblem):
         self.net = net_cifar10_3c3d(num_outputs=10)
         self.net.to(self._device)
         self.regularization_groups = self.get_regularization_groups()
-
-    def get_regularization_groups(self):
-        """Creates regularization groups for the parameters.
-
-        Returns:
-            dict: A dictionary where the key is the regularization factor and the value is a list of parameters.
-        """
-        no, l2 = 0.0, self._l2_reg
-        group_dict = {no: [], l2: []}
-
-        for parameters_name, parameters in self.net.named_parameters():
-            # penalize only the non bias layer parameters
-            if "bias" not in parameters_name:
-                group_dict[l2].append(parameters)
-            else:
-                group_dict[no].append(parameters)
-        return group_dict

--- a/deepobs/pytorch/testproblems/svhn_wrn164.py
+++ b/deepobs/pytorch/testproblems/svhn_wrn164.py
@@ -1,4 +1,3 @@
-import torch
 from torch import nn
 
 from ..datasets.svhn import svhn
@@ -47,6 +46,7 @@ class svhn_wrn164(TestProblem):
         self.net.to(self._device)
         self.regularization_groups = self.get_regularization_groups()
 
+    # TODO: Refactor, use WeightRegularizedTestproblem
     def get_regularization_groups(self):
         """Creates regularization groups for the parameters.
 

--- a/deepobs/pytorch/testproblems/testproblem.py
+++ b/deepobs/pytorch/testproblems/testproblem.py
@@ -203,7 +203,6 @@ class TestProblem(abc.ABC):
 class WeightRegularizedTestproblem(TestProblem):
     """Test problem with l2 regularization on weights, none on bias."""
 
-    @abc.abstractmethod
     def get_regularization_groups(self):
         """Creates regularization groups for the parameters.
 

--- a/tests/pytorch/bug/vgg19.py
+++ b/tests/pytorch/bug/vgg19.py
@@ -1,0 +1,18 @@
+from deepobs.pytorch.testproblems import cifar100_vgg19, cifar10_vgg19
+
+
+def perform_train_forward_pass(tproblem):
+    tproblem.set_up()
+    tproblem.train_init_op()
+    loss, acc = tproblem.get_batch_loss_and_accuracy()
+    return loss, acc
+
+
+def test_train_forward_pass_cifar100_vgg19():
+    tproblem = cifar100_vgg19(batch_size = 1)
+    perform_train_forward_pass(tproblem)
+
+
+def test_train_forward_pass_cifar10_vgg19():
+    tproblem = cifar10_vgg19(batch_size = 1)
+    perform_train_forward_pass(tproblem)


### PR DESCRIPTION
- The forward pass for VGG19 was not working on CIFAR10, CIFAR100. I added tests that fail before and pass after the fix
- Test problems with regularization penalize only the weights and not the bias terms. Hoisted the implementation to create the parameter groups by implementing a new test problem class
- @fsschneider: I was not sure about regularization for the WRNs. We should discuss and refactor them as well.