### PR TITLE
Deterministic rotation/Hessian

### DIFF
--- a/deepobs/pytorch/testproblems/quadratic_deep.py
+++ b/deepobs/pytorch/testproblems/quadratic_deep.py
@@ -8,10 +8,8 @@ from ..datasets.quadratic import quadratic
 from .testproblem import UnregularizedTestproblem
 from .testproblems_modules import net_quadratic_deep
 
-rng = np.random.RandomState(42)
 
-
-def random_rotation(D):
+def random_rotation(D, rng=None):
     """Produces a rotation matrix R in SO(D) (the special orthogonal
     group SO(D), or orthogonal matrices with unit determinant, drawn uniformly
     from the Haar measure.
@@ -22,11 +20,14 @@ def random_rotation(D):
 
     Args:
         D (int): Dimensionality of the matrix.
+        rng (numpy.random.RandomState, optional): A random number generator.
 
     Returns:
         np.array: Random rotation matrix ``R``.
 
     """
+    if rng is None:
+        rng = np.random.RandomState(42)
     assert D >= 2
     D = int(D)  # make sure that the dimension is an integer
 
@@ -100,7 +101,7 @@ class quadratic_deep(UnregularizedTestproblem):
             0., 1., eigvals_small), rng.uniform(30., 60., eigvals_large)),
                                      axis=0)
         D = np.diag(eigenvalues)
-        R = random_rotation(D.shape[0])
+        R = random_rotation(D.shape[0], rng=rng)
         Hessian = np.matmul(np.transpose(R), np.matmul(D, R))
         return torch.from_numpy(Hessian).to(torch.float32)
 

--- a/tests/pytorch/testproblems/test_quadratic_deep.py
+++ b/tests/pytorch/testproblems/test_quadratic_deep.py
@@ -74,6 +74,10 @@ class Quadratic_DeepTest(unittest.TestCase):
         check_hessian = torch.einsum("ij,kj->ik", (sqrt, sqrt))
         assert torch.allclose(hessian, check_hessian, rtol=1e-6, atol=1e-6)
 
+    def test_hessian_deterministic(self):
+        hessian1 = self.quadratic_deep._make_hessian()
+        hessian2 = self.quadratic_deep._make_hessian()
+        assert torch.allclose(hessian1, hessian2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Background: I fixed the seed of `torch/scipy/numpy/random` and created a `quadratic_deep` test problem. Then I performed a forward pass. Then I did exactly the same a second time and expected the result of the forward pass to be the same. This was not true.

Reason: Creating two `quadratic_deep` problems results in different Hessians, as the random number generator used to generate them lives on the module level, and I could not 'reset' it.

This PR moves the random number generator to the functional level.

Demo:
- Before:  `h1` is different from `h2`
- After: `h1` is equal to `h2`

```python
import random

import numpy

import torch
from deepobs.pytorch.testproblems import quadratic_deep

# set seed
seed = 0
random.seed(seed)
numpy.random.seed(seed)
torch.manual_seed(seed)

# first problem
tp1 = quadratic_deep(5)
tp1.set_up()
h1 = tp1._hessian

# set seed
random.seed(seed)
numpy.random.seed(seed)
torch.manual_seed(seed)

# second problem
tp2 = quadratic_deep(5)
tp2.set_up()
h2 = tp2._hessian

# should be the same Hessian
print(torch.allclose(h1, h2))
```