### PR TITLE
Cifar100 wrn404 regularization

### DIFF
--- a/deepobs/pytorch/testproblems/cifar100_wrn404.py
+++ b/deepobs/pytorch/testproblems/cifar100_wrn404.py
@@ -66,4 +66,4 @@ class cifar100_wrn404(TestProblem):
                 group_dict[l2].append(parameters)
             else:
                 group_dict[no].append(parameters)
-
+        return group_dict

--- a/tests/pytorch/testproblems/test_cifar100_wrn404.py
+++ b/tests/pytorch/testproblems/test_cifar100_wrn404.py
@@ -24,12 +24,12 @@ class Cifar100_WRN404Test(unittest.TestCase):
         """Sets up CIFAR-100 dataset for the tests."""
         self.batch_size = 100
         self.cifar100_wrn404 = testproblems.cifar100_wrn404(self.batch_size)
+        torch.manual_seed(42)
+        self.cifar100_wrn404.set_up()
+        self.cifar100_wrn404.train_init_op()
 
     def test_num_param(self):
         """Tests the number of parameters."""
-        torch.manual_seed(42)
-        self.cifar100_wrn404.set_up()
-
         num_param = []
         for parameter in self.cifar100_wrn404.net.parameters():
             num_param.append(parameter.numel())
@@ -154,6 +154,11 @@ class Cifar100_WRN404Test(unittest.TestCase):
         ]
 
         self.assertEqual(num_param, expected_num_param)
+
+    def test_forward_pass_with_regularization(self):
+        loss, _ = self.cifar100_wrn404.get_batch_loss_and_accuracy(
+            add_regularization_if_available=True
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Problem: `cifar100_wrn404` forward pass is not working when adding regularization.

This is caused by a missing return statement that creates the regularization groups.

Demo:
- Before: Forward pass without regularization passes, forward pass with regularization raises `AttributeError: 'NoneType' object has no attribute 'items'`
- After: Both forward passes work

```python
from deepobs.pytorch.testproblems import cifar100_wrn404

tp = cifar100_wrn404(5)
tp.set_up()
tp.train_init_op()

# works
loss, _ = tp.get_batch_loss_and_accuracy(add_regularization_if_available=False)
print(loss)

# crashes
regularized_loss, _ = tp.get_batch_loss_and_accuracy(
    add_regularization_if_available=True
)
print(regularized_loss)
```

Minor:
- Moved testproblem `set_up` method to `__init__` of test.